### PR TITLE
DOC: Remove documentation links from docstrings

### DIFF
--- a/src/flake8_absolute_import/__init__.py
+++ b/src/flake8_absolute_import/__init__.py
@@ -14,9 +14,6 @@ flake8 plugin to require absolute imports
 **Source Repository**
     http://www.github.com/bskinn/flake8-absolute-import
 
-**Documentation**
-    http://flake8-absolute-import.readthedocs.io
-
 **License**
     The MIT License; see |license_txt|_ for full license terms
 

--- a/src/flake8_absolute_import/core.py
+++ b/src/flake8_absolute_import/core.py
@@ -14,9 +14,6 @@ flake8 plugin to require absolute imports
 **Source Repository**
     http://www.github.com/bskinn/flake8-absolute-import
 
-**Documentation**
-    http://flake8-absolute-import.readthedocs.io
-
 **License**
     The MIT License; see |license_txt|_ for full license terms
 

--- a/src/flake8_absolute_import/version.py
+++ b/src/flake8_absolute_import/version.py
@@ -14,9 +14,6 @@ flake8 plugin to require absolute imports
 **Source Repository**
     http://www.github.com/bskinn/flake8-absolute-import
 
-**Documentation**
-    http://flake8-absolute-import.readthedocs.io
-
 **License**
     The MIT License; see |license_txt|_ for full license terms
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -14,9 +14,6 @@ flake8 plugin to require absolute imports
 **Source Repository**
     http://www.github.com/bskinn/flake8-absolute-import
 
-**Documentation**
-    http://flake8-absolute-import.readthedocs.io
-
 **License**
     The MIT License; see |license_txt|_ for full license terms
 


### PR DESCRIPTION
Not going to have RTD docs for this, at least to start.

Closes #2.