### PR TITLE
Freshen Azure and tox; drop f8 on conftest.py

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Brian Skinn
+Copyright (c) 2019-2020 Brian Skinn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Source on `GitHub <https://github.com/bskinn/flake8-absolute-import>`__.  Bug re
 and feature requests are welcomed at the
 `Issues <https://github.com/bskinn/flake8-absolute-import/issues>`__ page there.
 
-Copyright (c) Brian Skinn 2019
+Copyright (c) Brian Skinn 2019-2020
 
 License: The MIT License. See `LICENSE.txt <https://github.com/bskinn/flake8-absolute-import/blob/master/LICENSE.txt>`__
 for full license terms.

--- a/azure-job.yml
+++ b/azure-job.yml
@@ -11,13 +11,13 @@ jobs:
           ${{ image }}:
             image_name: ${{ coalesce(image, 'linux') }}
             ${{ if eq(image, 'linux') }}:
-              image: 'Ubuntu-16.04'
+              image: 'Ubuntu-latest'
             ${{ if eq(image, 'windows') }}:
-              image: 'windows-2019'
+              image: 'windows-latest'
             ${{ if eq(image, 'macOs') }}:
-              image: 'macOS-10.14'
+              image: 'macOS-latest'
             ${{ if notIn(image, 'macOs', 'linux', 'windows') }}:
-              image: ${{ coalesce(image, 'Ubuntu-16.04') }}
+              image: ${{ coalesce(image, 'Ubuntu-latest') }}
 
     pool:
       vmImage: $[ variables.image ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,14 +12,14 @@ jobs:
 - template: azure-job.yml
   parameters:
     pythons:
-      py34:
-        spec: '3.4'
       py35:
         spec: '3.5'
       py36:
         spec: '3.6'
       py37:
         spec: '3.7'
+      py38:
+        spec: '3.8'
     images: [linux, windows, macOs]
 
 - job: flake8
@@ -28,7 +28,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.8'
 
     - script: pip install -U tox
       displayName: Install tox
@@ -45,7 +45,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.8'
 
     - script: pip install -r requirements-ci.txt
       displayName: Install CI requirements

--- a/src/flake8_absolute_import/__init__.py
+++ b/src/flake8_absolute_import/__init__.py
@@ -9,10 +9,10 @@ flake8 plugin to require absolute imports
     6 Sep 2019
 
 **Copyright**
-    \(c) Brian Skinn 2019
+    \(c) Brian Skinn 2019-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/flake8-absolute-import
+    http://github.com/bskinn/flake8-absolute-import
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/flake8_absolute_import/core.py
+++ b/src/flake8_absolute_import/core.py
@@ -9,10 +9,10 @@ flake8 plugin to require absolute imports
     6 Sep 2019
 
 **Copyright**
-    \(c) Brian Skinn 2019
+    \(c) Brian Skinn 2019-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/flake8-absolute-import
+    http://github.com/bskinn/flake8-absolute-import
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/flake8_absolute_import/version.py
+++ b/src/flake8_absolute_import/version.py
@@ -9,10 +9,10 @@ flake8 plugin to require absolute imports
     6 Sep 2019
 
 **Copyright**
-    \(c) Brian Skinn 2019
+    \(c) Brian Skinn 2019-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/flake8-absolute-import
+    http://github.com/bskinn/flake8-absolute-import
 
 **License**
     The MIT License; see |license_txt|_ for full license terms
@@ -21,4 +21,4 @@ flake8 plugin to require absolute imports
 
 """
 
-__version__ = "1.0"
+__version__ = "1.0.1.dev0"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,10 +9,10 @@ flake8 plugin to require absolute imports
     6 Sep 2019
 
 **Copyright**
-    \(c) Brian Skinn 2019
+    \(c) Brian Skinn 2019-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/flake8-absolute-import
+    http://github.com/bskinn/flake8-absolute-import
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion=2.0
 isolated_build=True
 envlist=
     py3{4,5,6,7,8}-f8_{3_0,latest}
-    py37-f8_3_{1,2,3,4,5,6,7}
+    py37-f8_3_{1,2,3,4,5,6,7,8}
     sdist_install
 
 [testenv]
@@ -23,10 +23,12 @@ deps=
     f8_3_5:      flake8~=3.5.0
     f8_3_6:      flake8~=3.6.0
     f8_3_7:      flake8~=3.7.0
+    f8_3_8:      flake8~=3.8.0
 
 [testenv:win]
 platform=win
 basepython=
+    py38: C:\python38\python.exe
     py37: C:\python37\python.exe
     py36: C:\python36\python.exe
     py35: C:\python35\python.exe
@@ -35,6 +37,7 @@ basepython=
 [testenv:linux]
 platform=linux
 basepython=
+    py39: python3.9
     py38: python3.8
     py37: python3.7
     py36: python3.6
@@ -51,7 +54,7 @@ deps=
     -rrequirements-flake8.txt
 commands=
     flake8 --version
-    flake8 conftest.py tests src
+    flake8 tests src
 
 [pytest]
 addopts = -v -rsX -W error::Warning --strict


### PR DESCRIPTION
There *is* no conftest.py currently, and it seems the current
version of flake8 is now noisy by default if a file is provided
that it can't find. On the whole, a good change!