### PR TITLE
Soft re-enable of python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     provides=["flake8_absolute_import"],
-    python_requires=">=3.5",
+    python_requires=">=3.4",
     requires=["flake8 (>=3.7)"],
     install_requires=["flake8>=3.7"],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion=2.0
 isolated_build=True
 envlist=
-    py3{5,6,7,8,9}-f8_{3_7_0,latest}
+    py3{4,5,6,7,8,9}-f8_{3_7_0,latest}
     py38-f8_3_{7_x,8_x}
     sdist_install
 
@@ -36,6 +36,7 @@ basepython=
     py37: python3.7
     py36: python3.6
     py35: python3.5
+    py34: python3.4
 
 [testenv:sdist_install]
 commands=


### PR DESCRIPTION
Re-add to tox matrix, and bump the setup.py python_requires
back down. No reason to forcibly exclude 3.4 if it still works.